### PR TITLE
added the mongo-port-forward role back

### DIFF
--- a/ndtech-k8s-cluster/services/mongo/mongo-port-forward-role.yaml
+++ b/ndtech-k8s-cluster/services/mongo/mongo-port-forward-role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  # "namespace" omitted since ClusterRoles are not namespaced
+  name: mongo-port-forward
+  namespace: mongo
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", pods/portforward]
+  verbs: ["get", "list", "create"]


### PR DESCRIPTION
to allow rob and kim to port forward in the tekton-pipelines namespace.
This is required for them to view the tekton-dashboard